### PR TITLE
Allow User to Designate Color

### DIFF
--- a/R/forceNetwork.R
+++ b/R/forceNetwork.R
@@ -71,7 +71,7 @@
 #'
 #' @export
 forceNetwork <- function(Links, Nodes, Source, Target, Value = NULL, NodeID,
-	Group, height = NULL, width = NULL, fontsize = 7, linkDistance = 50,
+	Group, Color = NULL, height = NULL, width = NULL, fontsize = 7, linkDistance = 50,
 	linkWidth = "function(d) { return Math.sqrt(d.value); }", charge = -120,
 	linkColour = "#666",opacity = 0.6, zoom = FALSE)
 {
@@ -90,8 +90,15 @@ forceNetwork <- function(Links, Nodes, Source, Target, Value = NULL, NodeID,
 		LinksDF <- data.frame(Links[, Source], Links[, Target], Links[, Value])
 		names(LinksDF) <- c("source", "target", "value")
 	}
-	NodesDF <- data.frame(Nodes[, NodeID], Nodes[, Group])
-	names(NodesDF) <- c("name", "group")
+	
+	if (is.null(Color)) {
+		NodesDF <- data.frame(Nodes[, NodeID], Nodes[, Group])
+		names(NodesDF) <- c("name", "group")
+	}
+	else if (!is.null(Color)){
+		NodesDF <- data.frame(Nodes[, NodeID], Nodes[, Group], Nodes[, Color])
+		names(NodesDF) <- c("name", "group", "color")
+	}
 
 	# derive click text size
 	clickTextSize <- fontsize * 2.5

--- a/inst/htmlwidgets/forceNetwork.js
+++ b/inst/htmlwidgets/forceNetwork.js
@@ -89,7 +89,12 @@ HTMLWidgets.widget({
       .data(force.nodes())
       .enter().append("g")
       .attr("class", "node")
-      .style("fill", function(d) { return color(d.group); })
+      .style("fill", function(d) { if (d.color) { 
+									return d.color 
+									} else { 
+									return color(d.group); 
+									}
+								})
       .style("opacity", options.opacity)
       .on("mouseover", mouseover)
       .on("mouseout", mouseout)


### PR DESCRIPTION
This adds an argument to the forceNetwork function that adds a color
property to the data object if it is specified, in the same way that
Links can get Value. If the Color is specified then the output will
color the nodes whatever color is located in the color column. If people
don't use the argument, then the colors default to the color scalar as
normal.
